### PR TITLE
feat: Register Participant model in Django admin

### DIFF
--- a/etsd/msgs/admin.py
+++ b/etsd/msgs/admin.py
@@ -68,3 +68,10 @@ class DataAccessAdmin(admin.ModelAdmin):
         "data__message__protocol",
         "participant__authority__name",
     )
+
+@admin.register(models.Participant)
+class ParticipantAdmin(admin.ModelAdmin):
+    list_display = ("id", "authority", "message", "kind", "status")
+    list_filter = ("authority", "message", "kind", "status")
+    search_fields = ("id", "authority__name", "message__protocol")
+


### PR DESCRIPTION
This commit adds the `Participant` model to the Django administration site.

A `ParticipantAdmin` class has been created and registered to provide:
- `list_display`: `id`, `authority`, `message`, `kind`, and `status`.
- `list_filter`: Filtering by `authority`, `message`, `kind`, and `status`.
- `search_fields`: Searching by `id`, `authority` name, and `message` protocol.

This enhances the ability to view, filter, and manage `Participant` instances directly through the admin interface.