### PR TITLE
feat(filters): Allow filtering messages by local identifier

### DIFF
--- a/etsd/msgs/filters.py
+++ b/etsd/msgs/filters.py
@@ -44,6 +44,7 @@ class ParticipantFilter(django_filters.FilterSet):
             "message__rel_message__protocol": [
                 "exact",
             ],
+            "message__local_identifier": ["icontains"],
         }
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Adds a new filter option to the `ParticipantFilter` to enable searching messages by their `local_identifier`. This allows users to perform case-insensitive partial matches on the `local_identifier` field, improving searchability for related messages.